### PR TITLE
feat(engine): Process all files (and all rules within those files) asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ make cover-html
 Run the CLI locally:
 
 ```bash
-go run ./cmd/tfcoach lint examples
+go run main.go lint examples
 ```
 
 ---

--- a/examples/non_compliant/main2.tf
+++ b/examples/non_compliant/main2.tf
@@ -1,0 +1,17 @@
+data "archive_file" "zip" {}
+
+locals {}
+
+resource "null_resource" "tEst" {}
+
+resource "test" "is-complaint" {}
+
+output "test2" {
+  value = "test"
+}
+
+provider "aws2" {}
+
+terraform {}
+
+variable "test2" {}

--- a/examples/non_compliant/main3.tf
+++ b/examples/non_compliant/main3.tf
@@ -1,0 +1,17 @@
+data "archive_file" "zip" {}
+
+locals {}
+
+resource "null_resource" "tEst" {}
+
+resource "test" "is-complaint" {}
+
+output "test3" {
+  value = "test"
+}
+
+provider "aws3" {}
+
+terraform {}
+
+variable "test3" {}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
+const issuesChanBufSize = 3 // TODO later: choose appropriate buffer size (balance performance vs resource usage)
+
 type Engine struct {
 	src   Source
 	rules []Rule
@@ -33,7 +35,7 @@ func (e *Engine) Run(root string) ([]Issue, error) {
 		return nil, err
 	}
 
-	issuesChan := make(chan Issue, 3) // TODO: what buffer size?
+	issuesChan := make(chan Issue, issuesChanBufSize)
 	fileDoneChan := make(chan struct{})
 	var wg sync.WaitGroup
 	for _, path := range files {

--- a/internal/testutil/rule.go
+++ b/internal/testutil/rule.go
@@ -47,3 +47,27 @@ func (r AlwaysFlag) Apply(file string, f *hcl.File) []engine.Issue {
 	}
 	return nil
 }
+
+type NeverFlag struct {
+	RuleID  string
+	Message string
+}
+
+func (r NeverFlag) ID() string { return r.RuleID }
+
+func (r NeverFlag) META() engine.RuleMeta {
+	return engine.RuleMeta{
+		Title:       "NeverFlag",
+		Description: r.Message,
+		Severity:    "HIGH",
+		DocsURL:     "tbd",
+	}
+}
+
+func (r NeverFlag) Apply(_ string, f *hcl.File) []engine.Issue {
+	body, _ := f.Body.(*hclsyntax.Body)
+	if body == nil {
+		return nil
+	}
+	return []engine.Issue{}
+}


### PR DESCRIPTION
This PR makes use of Go channels to enable processing files in parallel. The rules for each file are also applied in parallel. The concurrency can be configured by increasing or decreasing the channel buffer size.